### PR TITLE
test: Add Python 3.11 to testing matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
Closes #19

**- What I did**

Broadened test coverage to use the latest bugfix version of Python

**- How I did it**

Added Python 3.11 to test matrix

**- How to verify it**

Test matrix will run on this PR

**- Description for the changelog**

test: Add Python 3.11 to testing matrix