### PR TITLE
ci: Don't skip whole job for Dependabot PRs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,8 +14,8 @@ permissions:  # added using https://github.com/step-security/secure-repo
 
 jobs:
   build:
-    # Don't run on PRs from a fork or Dependabot as the secrets aren't available
-    if: ${{ github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'}}
+    # Don't run on PRs from a fork as the secrets aren't available
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1


### PR DESCRIPTION
CI is presently being skipped entirely for Dependabot PRs, which is dinging our OSSF Scorecard:

![image](https://github.com/atsign-foundation/at_python/assets/478926/e468cc7e-eb1e-4c44-9210-f159e43f7bd4)

However since #26 we should be allowing Dependabot PRs to run the job, as tests needing secrets will be skipped

**- What I did**

Modified the job conditional to only apply to forks

**- How to verify it**

We will need to wait for the next Dependabot PR

**- Description for the changelog**

ci: Don't skip whole job for Dependabot PRs