### PR TITLE
ci: Timeout job after 15m

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ jobs:
     # Don't run on PRs from a fork as the secrets aren't available
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       max-parallel: 1
       fail-fast: false


### PR DESCRIPTION
Jobs are frequently hanging and timing out after the default 6h

**- What I did**

Added a shorter timeout. Each job in the matrix typically takes <1m, so 15m is 3x what it should take to run all 5

**- How to verify it**

Observe future workflow runs.

**- Description for the changelog**

ci: Timeout job after 15m