### PR TITLE
fix: Typo s/Montior/Monitor

### DIFF
--- a/at_client/connections/atmonitorconnection.py
+++ b/at_client/connections/atmonitorconnection.py
@@ -120,7 +120,7 @@ class AtMonitorConnection(AtSecondaryConnection):
             monitor_cmd = "monitor:" + str(self.last_received_time) + " " + regex
             what = "send monitor command " + monitor_cmd
             self.execute_command(command=monitor_cmd, retry_on_exception=True, read_the_response=False)
-            print("Montior started on " + str(self.atsign.to_string()))
+            print("Monitor started on " + str(self.atsign.to_string()))
             entered = False
             should_be_running_lock.acquire(blocking=1)
             while self.should_be_running:


### PR DESCRIPTION
Typo in `Montior started on`

**- What I did**

s/Montior/Monitor

**- Description for the changelog**

fix: Typo s/Montior/Monitor