### PR TITLE
build(deps): Bump urllib3 to 2.0.7

### DIFF
--- a/requirements.dev
+++ b/requirements.dev
@@ -220,6 +220,6 @@ six==1.16.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
 tomli==2.0.1 ; python_full_version >= "3.8.1" and python_version < "3.11" \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
-urllib3==2.0.6 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
-    --hash=sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2 \
-    --hash=sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564
+urllib3==2.0.7 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+    --hash=sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84 \
+    --hash=sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e

--- a/requirements.txt
+++ b/requirements.txt
@@ -184,6 +184,6 @@ requests==2.31.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0
 six==1.16.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-urllib3==2.0.6 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
-    --hash=sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2 \
-    --hash=sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564
+urllib3==2.0.7 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+    --hash=sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84 \
+    --hash=sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -3,6 +3,9 @@
 # update the requirements.txt, which is what we actually use to pull
 # in our Python dependencies. So we need to run this to generate a
 # new requirements.txt from the updated files.
+if ! [ -f poetry.lock ]; then
+  rm poetry.lock
+fi
 poetry export --format requirements.txt --output requirements.txt
 poetry export --format requirements.txt --output requirements.dev --with dev
 # of course this assumes that poetry is installed, which is done by:


### PR DESCRIPTION
https://github.com/atsign-foundation/at_python/security/dependabot/2

**- What I did**

Bumped urllib3 to 2.0.7

**- How I did it**

```
git checkout trunk
git pull
git checkout -b cpswan-bump-urllib3-2.0.7
rm poetry.lock
./update_requirements.sh
git diff
git add .
git commit -m 'build(deps): Bump urllib3 to 2.0.7'
git status
git push
```

**- How to verify it**

Dependabot alert will be closed

**- Description for the changelog**

build(deps): Bump urllib3 to 2.0.7