### PR TITLE
ci: build-publish fixes

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,6 +14,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 jobs:
   build:
     name: Build package
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout this repo
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
 name = "atsdk"
-version = "0.0.3"
+version = "0.0.4"
 description = "Python SDK for atPlatform"
-authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <@cpswan>"]
-maintainers = ["Chris Swan <@cpswan>"]
+authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
+maintainers = ["Chris Swan <chris@atsign.com>"]
 readme = "README.md"
 packages = [{include = "at_client"}]
 homepage = "https://github.com/atsign-foundation/at_python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "at_python"
-version = "0.0.2"
+name = "atsdk"
+version = "0.0.3"
 description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <@cpswan>"]
 maintainers = ["Chris Swan <@cpswan>"]


### PR DESCRIPTION
First attempt at build automation with #102 didn't work

**- What I did**

* added missing `runs-on` section
* renamed package to `atsdk` to avoid collisions on (Test)PyPI
* put my full email address into pyproject.toml

**- How to verify it**

manual run against this branch has already succeeded

**- Description for the changelog**

ci: build-publish fixes