### PR TITLE
fix: Set skip-existing for TestPyPI publishing

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11
       with:
+        skip-existing: true
         repository-url: https://test.pypi.org/legacy/
 
   publish-to-pypi:


### PR DESCRIPTION
Actions runs for build-publish are presently failing each time there's a commit to trunk as we're trying to push the same package to TestPyPI:

![image](https://github.com/atsign-foundation/at_python/assets/478926/17ae0bd2-8952-4125-9420-47b0d6d62689)

**- What I did**

Set `skip-existing: true`

**- How I did it**

Per https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#tolerating-release-package-file-duplicates

**- How to verify it**

This merge should have a passing Action run for build-publish

**- Description for the changelog**

fix: Set skip-existing for TestPyPI publishing