### PR TITLE
fix: Don't attempt to create a release

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -109,14 +109,6 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The present build-publish workflow attempts to create a release, which fails when we trigger the workflow by tagging a new release, as the release already exists

**- What I did**

Removed step that creates a release

**- How I did it**

I manually ran the final step to test upload artifact to an existing release:

```sh
rm dist/*
poetry build
gh release upload 'v0.1.0' dist/** --repo 'atsign-foundation/at_python'
```

**- How to verify it**

Will need to wait for next release

**- Description for the changelog**

fix: Don't attempt to create a release