### PR TITLE
fix: Deployment URLs s/at_python/atsdk

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/at_python
+      url: https://test.pypi.org/p/atsdk
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/at_python
+      url: https://pypi.org/p/atsdk
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 


### PR DESCRIPTION
GotHub Actions workflows were showing a link to at_python (which exists on TestPyPI, but isn't ours) rather than atsdk

**- What I did**

s/at_python/atsdk/

**- How to verify it**

Next runs of actions should show correct URL to package

**- Description for the changelog**

fix: Deployment URLs s/at_python/atsdk
