### PR TITLE
ci: Automate future version bumps

### DIFF
--- a/.github/workflows/update_python_requirements.yml
+++ b/.github/workflows/update_python_requirements.yml
@@ -46,6 +46,8 @@ jobs:
           echo 'No changes to commit on this run'
           exit 0
         else
-          git commit -m "build(deps): Bump requirements.txt"
+          poetry version patch
+          git add pyproject.toml
+          git commit -m "build(deps): Bump requirements.txt and poetry version"
           git push
         fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atsdk"
-version = "0.2.3"
+version = "0.2.4"
 description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
 maintainers = ["Chris Swan <chris@atsign.com>"]


### PR DESCRIPTION
I have been manually bumping the pyproject.toml patch version each time there's a Dependabot PR to bump the dependencies (usually cryptography). This change will automate that process

**- What I did**

Added `poetry version patch` to the workflow

**- How to verify it**

The next Dependabot PR for Python deps should carry a bump to the version number.

**- Description for the changelog**

ci: Automate future version bumps