### PR TITLE
build(deps): Bump idna to 3.7

### DIFF
--- a/requirements.dev
+++ b/requirements.dev
@@ -187,9 +187,9 @@ exceptiongroup==1.2.0 ; python_full_version >= "3.8.1" and python_version < "3.1
 flake8==7.0.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132 \
     --hash=sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3
-idna==3.6 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
-    --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
-    --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
+idna==3.7 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+    --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
+    --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
 iniconfig==2.0.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,9 +178,9 @@ cryptography==42.0.5 ; python_full_version >= "3.8.1" and python_full_version < 
     --hash=sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e \
     --hash=sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac \
     --hash=sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7
-idna==3.6 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
-    --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
-    --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
+idna==3.7 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+    --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
+    --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
 pycparser==2.22 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/at_python/security/dependabot/6

**- What I did**

Regenerated requirements.txt to use new version of idna

**- How I did it**

`./update_requirements.sh`

**- How to verify it**

Security alert will clear when merged

**- Description for the changelog**

build(deps): Bump idna to 3.7