### PR TITLE
fix: fixed regex missing from heartbeat method

### DIFF
--- a/at_client/atclient.py
+++ b/at_client/atclient.py
@@ -343,21 +343,21 @@ class AtClient(ABC):
         if self.secondary_connection:
             self.secondary_connection.disconnect()
 
-    def start_monitor(self, regex=""):
+    def start_monitor(self, regex=".*"):
         if self.queue != None:
             global should_be_running_lock
             what = ""
             try:
                 if self.monitor_connection == None:
                     what = "construct an AtMonitorConnection"
-                    self.monitor_connection = AtMonitorConnection(queue=self.queue, atsign=self.atsign, address=self.secondary_address, verbose=self.verbose)
+                    self.monitor_connection = AtMonitorConnection(queue=self.queue, atsign=self.atsign, address=self.secondary_address, verbose=self.verbose, regex=regex)
                     self.monitor_connection.connect()
                     AuthUtil.authenticate_with_pkam(self.monitor_connection, self.atsign, self.keys)
                 should_be_running_lock.acquire(blocking=1)
                 if not self.monitor_connection.running:
                     should_be_running_lock.release()
                     what = "call monitor_connection.start_monitor()"
-                    self.monitor_connection.start_monitor(regex)
+                    self.monitor_connection.start_monitor()
                 else:
                     should_be_running_lock.release()
             except Exception as e:


### PR DESCRIPTION
**- What I did**
  Removed regex as a parameter from the monitor methods
  helps fix [Python sshnpd unreliable](https://github.com/atsign-foundation/noports/issues/1025#issuecomment-2091320708)
  
**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: regex missing from heartbeat method
