### PR TITLE
ci: Add SBOMs and use GitHub attestation

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -94,16 +94,17 @@ jobs:
       uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
 
   github-release:
-    name: >-
-      Sign the Python distribution with Sigstore
-      and upload them to GitHub Release
+    name: Attest Python distribution artifacts and upload them to the GitHub Release
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore
+      attestations: write
 
     steps:
     - name: Download all the dists
@@ -111,12 +112,30 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2 # v2.1.1
+    - name: Checkout requirements.txt
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
+        sparse-checkout: requirements.txt
+        sparse-checkout-cone-mode: false
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11
+    - name: Generate SBOMs
+      run: |
+        syft scan file:./requirements.txt \
+          -o 'spdx-json=dist/sbom.spdx.json' \
+          -o 'cyclonedx-json=dist/sbom.cyclonedx.json'
+    - name: Generate SHA256 checksums
+      working-directory: dist
+      run: sha256sum * > checksums.txt
+    - id: hash
+      name: Pass artifact hashes for SLSA provenance
+      working-directory: dist
+      run: |
+        echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+    - name: Attest the release artifacts
+      uses: actions/attest-build-provenance@f8d5ea8082b0d9f5ab855907be308fbd7eefb155 # v1.1.0
+      with:
+        subject-path: 'dist/**'
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -127,3 +146,14 @@ jobs:
         gh release upload
         '${{ github.ref_name }}' dist/**
         --repo '${{ github.repository }}'
+
+  provenance:
+    needs: [github-release]
+    permissions:
+      actions: read # Needed for detection of GitHub Actions environment.
+      id-token: write # Needed for provenance signing and ID
+      contents: write # Needed for release uploads
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0 # 5a775b367a56d5bd118a224a811bba288150a563
+    with:
+      base64-subjects: "${{ needs.github-release.outputs.hashes }}"
+      upload-assets: true


### PR DESCRIPTION
The new [GitHub artifact attestation](https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/) mechanism is much easier to verify than .sigstore

**- What I did**

* Replaced .sigstore with attestation
* Added SBOMs in SPDX and CycloneDX formats
* SLSA attestation

**- How I did it**

Based on [slsa_attest_release workflow](https://github.com/cpswan/release_automation/blob/main/.github/workflows/slsa_attest_release.yml) in my release_automation repo

**- How to verify it**

We'll have to do a release for full verification, though the basics can be tested with a manual workflow_dispatch.

**- Description for the changelog**

ci: Add SBOMs and use GitHub attestation