### PR TITLE
build(deps): Minimise top level requirements in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atsdk"
-version = "0.2.13"
+version = "0.2.14"
 description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
 maintainers = ["Chris Swan <chris@atsign.com>"]
@@ -10,12 +10,9 @@ homepage = "https://github.com/atsign-foundation/at_python"
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-cffi = "1.16.0"
 cryptography = "42.0.7"
-pycparser = "2.22"
 python-dateutil = "2.9.0.post0"
 requests = "2.31.0"
-six = "1.16.0"
 
 [tool.poetry.group.dev.dependencies]
 pip ="24.0"

--- a/requirements.dev
+++ b/requirements.dev
@@ -1,7 +1,7 @@
 certifi==2024.2.2 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f \
     --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
-cffi==1.16.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+cffi==1.16.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" and platform_python_implementation != "PyPy" \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
     --hash=sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a \
     --hash=sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417 \
@@ -208,7 +208,7 @@ pluggy==1.5.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0"
 pycodestyle==2.11.1 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f \
     --hash=sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67
-pycparser==2.22 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+pycparser==2.22 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" and platform_python_implementation != "PyPy" \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
 pyflakes==3.2.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.2.2 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f \
     --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
-cffi==1.16.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+cffi==1.16.0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" and platform_python_implementation != "PyPy" \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
     --hash=sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a \
     --hash=sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417 \
@@ -181,7 +181,7 @@ cryptography==42.0.7 ; python_full_version >= "3.8.1" and python_full_version < 
 idna==3.7 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
     --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
     --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
-pycparser==2.22 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \
+pycparser==2.22 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" and platform_python_implementation != "PyPy" \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
 python-dateutil==2.9.0.post0 ; python_full_version >= "3.8.1" and python_full_version < "4.0.0" \


### PR DESCRIPTION
A number of the packages we specified in pyproject.toml aren't direct dependencies, and can be left to pip rather than being declared

**- What I did**

Stripped out packages that we don't import ourselves

**- How I did it**

Inspection of imports and generated requirements.txt after removing packages

**- How to verify it**

CI will still pass

**- Description for the changelog**

build(deps): Minimise top level requirements in pyproject.toml
