### PR TITLE
test: Test for AT00015 rather than AT00011

### DIFF
--- a/test/atclient_test.py
+++ b/test/atclient_test.py
@@ -195,7 +195,7 @@ class AtClientTest(unittest.TestCase):
         self.assertEqual("test1", response)
 
         # Public Key not found test
-        with self.assertRaises(AtInternalServerException):
+        with self.assertRaises(AtKeyNotFoundException):
             unknown_pk = PublicKey("unknown_key", atsign)
             response = atclient.get(unknown_pk)
 


### PR DESCRIPTION
Tests have been failing e.g. https://github.com/atsign-foundation/at_python/actions/runs/9345008662

It _looks_ like we're getting an AT00015 from the atServer when we're expecting an AT00011.

AT00015 would seem to be the correct code for this test, but maybe there's been a recent fix in at_server to correct this? @gkc @murali-shris @sitaram-kalluri I'd appreciate any insight you can share on that.

**- What I did**

Modified the exception type we expect to see.

**- How to verify it**

CI should pass on this PR

**- Description for the changelog**

test: Test for AT00015 rather than AT00011