### PR TITLE
ci: Add Python 3.13 to the test matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout at_python


### PR DESCRIPTION
Python 3.13 has been [released](https://www.python.org/downloads/release/python-3130/) as stable

**- What I did**

Added 3.13 to the test matrix

**- How to verify it**

CI

**- Description for the changelog**

ci: Add Python 3.13 to the test matrix
