### PR TITLE
build: Use sbomify to generate SBOM

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -112,13 +112,17 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Install Syft
-      uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
-    - name: Generate SBOMs
-      run: |
-        syft scan file:./requirements.txt \
-          -o 'spdx-json=dist/sbom.spdx.json' \
-          -o 'cyclonedx-json=dist/sbom.cyclonedx.json'
+    - name: Generate SBOM
+      uses: sbomify/github-action@3d1dd70ca4e6fdbe5b1cd1bcd4a23b1ec085dc3e # v0.2.0
+      env:
+        TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+        COMPONENT_ID: 'wy8Kpn8rF9'
+        LOCK_FILE: './requirements.txt'
+        SBOM_VERSION: ${{github.ref_name}}
+        OUTPUT_FILE: 'dist/sbom.cyclonedx.json'
+        AUGMENT: true
+        ENRICH: true
+        UPLOAD: true
     - name: Generate SHA256 checksums
       working-directory: dist
       run: sha256sum * > checksums.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atsdk"
-version = "0.2.31"
+version = "0.2.32"
 description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
 maintainers = ["Chris Swan <chris@atsign.com>"]


### PR DESCRIPTION
Related to https://github.com/atsign-foundation/operations/issues/139

**- What I did**

Replaced Syft generation of SBOMs with sbomify

**- How I did it**

Populated sbomify console with product, projects and components then pasted (modified) version of the GitHub Actions boilerplate in place of previous SBOM generation.

**- How to verify it**

We will need to do a 0.2.32 release (pyproject.toml bumped in anticipation)

**- Description for the changelog**

build: Use sbomify to generate SBOM
