### PR TITLE
chore: More descriptive SBOM naming

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -119,7 +119,7 @@ jobs:
         COMPONENT_ID: 'wy8Kpn8rF9'
         LOCK_FILE: './requirements.txt'
         SBOM_VERSION: ${{github.ref_name}}
-        OUTPUT_FILE: 'dist/sbom.cyclonedx.json'
+        OUTPUT_FILE: 'dist/at_python-${{github.ref_name}}-sbom.cdx.json'
         AUGMENT: true
         ENRICH: true
         UPLOAD: true


### PR DESCRIPTION
`sbom.cyclonedx.json` doesn't say what it's for or what version (without looking inside)

**- What I did**

Future SBOMs will take the form:

repo-version-sbom.cdx.json

**- How to verify it**

Will require another release. Happy to wait for that to occur naturally (e.g. the next Python deps bump).

**- Description for the changelog**

chore: More descriptive SBOM naming