### PR TITLE
build(deps): Bump Python to 3.13 and Poetry to 2.0.1

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-          python-version: '3.11'
+          python-version: '3.13'
     - name: Install Poetry
       uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1 # v4.0.0
       with:
-        poetry-version: '1.8.5'
+        poetry-version: '2.0.0'
     # The dark mode and light mode Atsign logos in the GitHub README don't
     # show properly on PyPI so we have a copy of the README.md in
     # README.PyPI.md with just the light mode logo.

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -102,10 +102,10 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
       attestations: write
     steps:
-    - name: Checkout requirements.txt
+    - name: Checkout poetry.lock
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        sparse-checkout: requirements.txt
+        sparse-checkout: poetry.lock
         sparse-checkout-cone-mode: false
     - name: Download all the dists
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -117,7 +117,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
         COMPONENT_ID: 'wy8Kpn8rF9'
-        LOCK_FILE: './requirements.txt'
+        LOCK_FILE: './poetry.lock'
         SBOM_VERSION: ${{github.ref_name}}
         OUTPUT_FILE: 'dist/at_python-${{github.ref_name}}-sbom.cdx.json'
         AUGMENT: true

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Poetry
       uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1 # v4.0.0
       with:
-        poetry-version: '2.0.0'
+        poetry-version: '2.0.1'
     # The dark mode and light mode Atsign logos in the GitHub README don't
     # show properly on PyPI so we have a copy of the README.md in
     # README.PyPI.md with just the light mode logo.


### PR DESCRIPTION
Updating workflow to use latest stable versions

Fixed workflow to use the right lock file.

**- What I did**

* Python to 3.13
* Poetry to 2.0.1
* Updated SBOM section of workflow to use poetry.lock rather than requirements.txt

**- How to verify it**

CI on merge

**- Description for the changelog**

build(deps): Bump Python to 3.13 and Poetry to 2.0.1
