### PR TITLE
ci: Workflow to bump version on Dependabot changes

### DIFF
--- a/.github/workflows/bump-pyproject.yml
+++ b/.github/workflows/bump-pyproject.yml
@@ -1,0 +1,40 @@
+name: Bump pyproject.toml
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+
+permissions:
+  pull-requests: write
+  
+jobs:
+  bump_requirements:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout this repo
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ secrets.MY_GITHUB_TOKEN }}
+
+    - name: Set up Python
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      with:
+          python-version: '3.13'
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@e78f54a89cb052fff327414dd9ff010b5d2b4dbd # v3.0.1
+      with:
+        poetry-version: '1.8.2'
+    
+    - name: Bump Python dependencies
+      run: |
+        git config --global user.name 'library-action[bot]'
+        git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        poetry version patch
+        git add pyproject.toml
+        git commit -m "build(deps): Bump poetry version"
+        git push


### PR DESCRIPTION
Removal of the previous requirements.txt based workflow means that pyproject.toml isn't having its version bumped when Dependabot makes changes to dependencies.

**- What I did**

New workflow that just works for pyproject.toml

**- How I did it**

Based on old workflow

**- How to verify it**

I'll recreate #330 once this is merged

**- Description for the changelog**

ci: Workflow to bump version on Dependabot changes
