### PR TITLE
ci: Checkout `pyproject.toml` in addition to `poetry.lock`

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -102,10 +102,12 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
       attestations: write
     steps:
-    - name: Checkout poetry.lock
+    - name: Checkout poetry.lock and pyproject.toml
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        sparse-checkout: poetry.lock
+        sparse-checkout: |
+          poetry.lock
+          pyproject.toml
         sparse-checkout-cone-mode: false
     - name: Download all the dists
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9


### PR DESCRIPTION
The sbomify action is failing in [this job](https://github.com/atsign-foundation/at_python/actions/runs/13624697093) due to the fact that `pyprojects.toml` isn't accessible to `cyclonedx-py`. This PR adds this file to the run.