### PR TITLE
build(deps): Deprecate Python 3.8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout at_python

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ dependency requirements). As of 7 Oct 2024 Python 3.8 is end-of-life, and
 will no longer receive security patches. Occordingly we have
 [decided](https://github.com/atsign-foundation/at_protocol/blob/trunk/decisions/2024-10-python-deprecation.md)
 to continue support for 3.8 for another 6 months (on a best efforts basis).
-From 7 Apr 2025 Python 3.8 will be removed from the test matrix, and
-pyproject.toml will be bumped to require Python 3.9.
+As 7 Apr 2025 has now passed, Python 3.8 has been removeded from the test
+matrix, and pyproject.toml bumped to require Python 3.9(.2).
 
 Older versions of this package will of course remain available on
 [PyPI](https://pypi.org/project/atsdk/), though they may lack features,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atsdk"
-version = "0.2.35"
+version = "0.2.36"
 description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
 maintainers = ["Chris Swan <chris@atsign.com>"]
@@ -9,7 +9,7 @@ packages = [{include = "at_client"}]
 homepage = "https://github.com/atsign-foundation/at_python"
 
 [tool.poetry.dependencies]
-python = "!=3.9.0,!=3.9.1,>=3.8.1"
+python = ">=3.9.2"
 cryptography = "44.0.2"
 python-dateutil = "2.9.0.post0"
 requests = "2.32.3"


### PR DESCRIPTION
We announced that we'd deprecate Python 3.8 support after 7 Apr and we're now a few weeks past that.

**- What I did**

* Removed 3.8 from test matrix
* Bumped pyproject.toml
* Updated README

**- How to verify it**

Reduced test matrix will run against this PR

**- Description for the changelog**

build(deps): Deprecate Python 3.8