### PR TITLE
chore: Add license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
 maintainers = ["Chris Swan <chris@atsign.com>"]
 license = "BSD-3-Clause"
-license-files = ["LICENSE"]
 readme = "README.PyPI.md"
 packages = [{include = "at_client"}]
 homepage = "https://github.com/atsign-foundation/at_python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,11 @@
 [tool.poetry]
 name = "atsdk"
-version = "0.2.39"
+version = "0.2.40"
 description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
 maintainers = ["Chris Swan <chris@atsign.com>"]
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 readme = "README.PyPI.md"
 packages = [{include = "at_client"}]
 homepage = "https://github.com/atsign-foundation/at_python"


### PR DESCRIPTION
License isn't being shown in PyPI

**- What I did**

Added license and license-file to pyproject.toml

**- How I did it**

Based on PEP 639

**- How to verify it**

Publish new release then check PyPI

**- Description for the changelog**

chore: Add license metadata
