### PR TITLE
build(deps): Update to include Python 3.14 and deprecation notice for 3.9

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
-          python-version: '3.13'
+          python-version: '3.14'
     - name: Install Poetry
       uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1 # v4.0.0
       with:
-        poetry-version: '2.0.1'
+        poetry-version: '2.2.1'
     # The dark mode and light mode Atsign logos in the GitHub README don't
     # show properly on PyPI so we have a copy of the README.md in
     # README.PyPI.md with just the light mode logo.

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Checkout at_python

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@
 This repo contains library, samples and examples for developers who wish
 to work with the atPlatform from Python code.
 
-## Python 3.8 deprecation
+## Python 3.9 deprecation
 
-This SDK was created to support Python 3.8 (specifically 3.8.1 due to some
-dependency requirements). As of 7 Oct 2024 Python 3.8 is end-of-life, and
-will no longer receive security patches. Occordingly we have
+As of Oct 2025 Python 3.9 is end-of-life, and will no longer receive
+security patches. We have previously
 [decided](https://github.com/atsign-foundation/at_protocol/blob/trunk/decisions/2024-10-python-deprecation.md)
-to continue support for 3.8 for another 6 months (on a best efforts basis).
-As 7 Apr 2025 has now passed, Python 3.8 has been removeded from the test
-matrix, and pyproject.toml bumped to require Python 3.9(.2).
+to continue support for 3.9 for another 6 months (on a best efforts basis).
+From Apr 2026, Python 3.9 will be removeded from the test
+matrix, and pyproject.toml bumped to require Python 3.10.
 
 Older versions of this package will of course remain available on
 [PyPI](https://pypi.org/project/atsdk/), though they may lack features,


### PR DESCRIPTION
Fixes #420

**- What I did**

* Added 3.14 to test matrix
* Use 3.14 and latest Poetry for builds
* Update 3.8 deprecation notice to reference 3.9

**- How to verify it**

New test matrix will run against this PR

**- Description for the changelog**

build(deps): Update to include Python 3.14 and deprecation notice for 3.9
