### PR TITLE
fix: Ensure SBOM tags are unique

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -120,7 +120,7 @@ jobs:
         TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
         COMPONENT_ID: 'wy8Kpn8rF9'
         LOCK_FILE: './poetry.lock'
-        SBOM_VERSION: ${{github.ref_name}}
+        COMPONENT_VERSION: ${{github.ref_name}}-gha${{github.run_number}}
         OUTPUT_FILE: 'dist/at_python-${{github.ref_name}}-sbom.cdx.json'
         AUGMENT: true
         ENRICH: true


### PR DESCRIPTION
Same issue as https://github.com/atsign-foundation/noports/pull/2459

**- What I did**

Added GitHub Actions run number to COMPONENT_VERSION

**- How I did it**

Based on https://github.com/atsign-foundation/at_server/pull/2514

**- How to verify it**

Inspect sbomify trust centre on next release

**- Description for the changelog**

fix: Ensure SBOM tags are unique
