### PR TITLE
ci: Use attest rather than attest-build-provenance

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -134,7 +134,7 @@ jobs:
       run: |
         echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: Attest the release artifacts
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
         subject-path: 'dist/**'
     - name: Upload artifact signatures to GitHub Release


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/365

**- What I did**

* Replaced `attest-build-provenance` with `attest`

**- How I did it**

```diff
- uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+ uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
```

**- How to verify it**

Future releases still provide attestation in GitHub Actions log

**- Description for the changelog**

ci: Use attest rather than attest-build-provenance