### PR TITLE
fix: discard a connection whose reply was never read

### DIFF
--- a/at_client/connections/atconnection.py
+++ b/at_client/connections/atconnection.py
@@ -140,7 +140,16 @@ class AtConnection(ABC):
                 print(f"\tSENT: {repr(command.strip())}")
 
             if read_the_response:
-                raw_response = self.read()
+                try:
+                    raw_response = self.read()
+                except Exception:
+                    # The command was sent but its reply was not fully read, so the
+                    # reply is still queued on this socket. Reusing the connection
+                    # would hand that reply to the NEXT command, and every command
+                    # after it would read the previous one's response. Discard the
+                    # connection so the next use starts from a clean stream.
+                    self.disconnect()
+                    raise
                 if self._verbose:
                     print(f"\tRCVD: {repr(raw_response)}")
 

--- a/test/abandoned_read_test.py
+++ b/test/abandoned_read_test.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock
+
+from at_client.connections.atconnection import AtConnection
+from at_client.connections.response import Response
+
+
+class _TestConnection(AtConnection):
+    """Minimal concrete subclass so the base execute_command can be exercised."""
+
+    def parse_raw_response(self, raw_response):
+        text = raw_response.strip().rstrip('@')
+        return Response().set_raw_data_response(text[len('data:'):]
+                                                if text.startswith('data:') else text)
+
+
+class AbandonedReadTest(unittest.TestCase):
+    """A command whose reply is not read leaves that reply queued on the socket.
+
+    If the connection is reused, the next command receives the previous command's
+    answer and every command after it is one reply behind — so a lookup can return a
+    completely different record's value. The connection must therefore be discarded.
+    """
+
+    def _connection(self, read_side_effect):
+        connection = _TestConnection.__new__(_TestConnection)
+        connection._connected = True
+        connection._verbose = False
+        socket = MagicMock()
+        socket.read.side_effect = read_side_effect
+        connection._secure_root_socket = socket
+        return connection
+
+    def test_abandoned_read_discards_the_connection(self):
+        connection = self._connection(TimeoutError('The read operation timed out'))
+        with self.assertRaises(TimeoutError):
+            connection.execute_command('llookup:shared_key.bob@alice')
+        self.assertFalse(connection.is_connected(),
+                         'a connection with an unread reply must not be reused')
+
+    def test_successful_command_keeps_the_connection(self):
+        connection = self._connection([b'data:ok\n'])
+        response = connection.execute_command('llookup:phone.wavi@alice')
+        self.assertEqual(response.get_raw_data_response(), 'ok')
+        self.assertTrue(connection.is_connected())
+
+    def test_command_that_reads_no_reply_is_unaffected(self):
+        """`monitor` and `noop` are sent without reading a reply here."""
+        connection = self._connection(TimeoutError('should never be read'))
+        self.assertEqual(connection.execute_command('noop:0', read_the_response=False), '')
+        self.assertTrue(connection.is_connected())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The problem

If a command is sent and its reply is not fully read — a read timeout, or any error raised while reading — **that reply stays queued on the socket**. Reusing the connection hands it to the *next* command, and every command after that is one reply behind. A lookup can then return a completely different record's value, with no error raised anywhere.

## How it showed up

In a long-running deployment, publishing to one recipient began failing every cycle with:

```
Failed to decrypt shared_key.<recipient>@<sender>
  - Ciphertext length must be equal to key size.
```

The stored `shared_key` record was perfectly good. The lookup was returning the *previous* command's reply, which is not an RSA ciphertext. Restarting the process cleared it — the fault was in the connection, not the data.

Reproduced directly against a live atServer: after an abandoned read, `llookup:publickey@bravo` returned the earlier `shared_key` reply.

## The fix

`execute_command` disconnects when a reply cannot be read, so the next use starts from a clean stream (`disconnect()` clears `_connected`, so `connect()` rebuilds — #523).

Deliberately minimal:
- the **successful path is untouched** — the new handling only wraps the read;
- commands sent with `read_the_response=False` (`monitor`, `noop`) are unaffected;
- it composes with the existing `retry_on_exception` branch, which calls `connect()` and will now get a fresh socket.

This matters more as callers adopt read timeouts (which are otherwise the right way to stop a silently dead peer blocking forever): without this, a timeout trades a hang for a connection that quietly returns wrong answers.

## Tests

`test/abandoned_read_test.py`, network-free:

| Case | Expected |
|---|---|
| read raises (timeout) | exception propagates **and** the connection is left unusable |
| read succeeds | response parsed, connection still usable |
| `read_the_response=False` | unaffected, connection still usable |

## Related

Supersedes #544, which I closed: I had misattributed this incident to a damaged `shared_key` record. Since the desynchronised case reports the identical error, replacing the key there would have rotated a perfectly good shared key for both parties — fixing the cause is both safer and sufficient.