### PR TITLE
fix: Avoid use of TLS < v1.2

### DIFF
--- a/at_client/connections/atconnection.py
+++ b/at_client/connections/atconnection.py
@@ -15,16 +15,19 @@ class AtConnection(ABC):
     Abstract base class for connecting to and communicating with an atprotocol server.
     """
 
-    def __init__(self, host:str, port:int, context:ssl.SSLContext, verbose:bool=False):
+    def __init__(self, host:str, port:int, context:ssl.SSLContext=None, verbose:bool=False):
         """
         Initialize the AtConnection object.
 
         Parameters:
         - host (str): The host name or IP address of the server.
         - port (int): The port number of the server.
-        - context (ssl.SSLContext): The SSL context for secure connections.
+        - context (ssl.SSLContext, optional): The SSL context for secure connections.
         - verbose (bool, optional): Indicates if verbose output is enabled (default is False).
         """
+        if context is None:
+            context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLS1_2
         self._host = host
         self._port = port
         self._context = context

--- a/at_client/connections/atconnection.py
+++ b/at_client/connections/atconnection.py
@@ -25,12 +25,19 @@ class AtConnection(ABC):
         - context (ssl.SSLContext, optional): The SSL context for secure connections.
         - verbose (bool, optional): Indicates if verbose output is enabled (default is False).
         """
-        if context is None:
-            context = ssl.create_default_context()
-        context.minimum_version = ssl.TLSVersion.TLS1_2
+        if isinstance(context, ssl.SSLContext):
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            self._context = context
+        elif isinstance(context, bool):
+            verbose = context
+            self._context = ssl.create_default_context()
+            self._context.minimum_version = ssl.TLSVersion.TLSv1_2
+        else:
+            self._context = ssl.create_default_context()
+            self._context.minimum_version = ssl.TLSVersion.TLSv1_2
+
         self._host = host
         self._port = port
-        self._context = context
         self._addr_info = socket.getaddrinfo(host, port)[0][-1]
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._secure_root_socket = None

--- a/at_client/connections/atmonitorconnection.py
+++ b/at_client/connections/atmonitorconnection.py
@@ -18,7 +18,7 @@ class AtMonitorConnection(AtSecondaryConnection):
     should_be_running: bool = False
 
     def __init__(self, queue: queue.Queue, atsign: AtSign, address: Address,
-                 context: ssl.SSLContext = ssl.create_default_context(),
+                 context: ssl.SSLContext = None,
                  verbose: bool = True, regex=".*", last_received_time: int = 0):
         self.atsign = atsign
         self.queue = queue

--- a/at_client/connections/atrootconnection.py
+++ b/at_client/connections/atrootconnection.py
@@ -14,7 +14,7 @@ class AtRootConnection(AtConnection):
     __instance = None
 
     @staticmethod
-    def get_instance(host:str='root.atsign.org', port:int=64, context:ssl.SSLContext=ssl.create_default_context(), verbose:bool=False):
+    def get_instance(host:str='root.atsign.org', port:int=64, context:ssl.SSLContext=None, verbose:bool=False):
         """
         Get an instance of AtRootConnection using the singleton pattern.
 
@@ -25,7 +25,7 @@ class AtRootConnection(AtConnection):
         port : int, optional
             The port number of the root server (default is 64).
         context : ssl.SSLContext, optional
-            The SSL context for secure connections (default is ssl.create_default_context()).
+            The SSL context for secure connections (default is None).
         verbose : bool, optional
             Indicates if verbose output is enabled (default is False).
 

--- a/at_client/connections/atsecondaryconnection.py
+++ b/at_client/connections/atsecondaryconnection.py
@@ -9,7 +9,7 @@ class AtSecondaryConnection(AtConnection):
     Subclass of AtConnection representing a connection to the secondary server in the atprotocol.
     """
 
-    def __init__(self, address: Address, context:ssl.SSLContext=ssl.create_default_context(), verbose:bool=False):
+    def __init__(self, address: Address, context:ssl.SSLContext=None, verbose:bool=False):
         """
         Initialize the AtSecondaryConnection object.
 
@@ -20,7 +20,7 @@ class AtSecondaryConnection(AtConnection):
         port : int
             The port number of the secondary server.
         context : ssl.SSLContext, optional
-            The SSL context for secure connections (default is ssl.create_default_context()).
+            The SSL context for secure connections (default is None).
         verbose : bool, optional
             Indicates if verbose output is enabled (default is False).
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atsdk"
-version = "0.2.73"
+version = "0.2.74"
 description = "Python SDK for atPlatform"
 authors = ["Umang Shah <shahumang19@gmail.com>","Chris Swan <chris@atsign.com>"]
 maintainers = ["Chris Swan <chris@atsign.com>"]


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/at_python/security/code-scanning/13

**- What I did**

Enforce minimum version of TLS 1.2

**- How I did it**

agy prompt:

```log
codeql has identified an issue with at_client/connections/atconnection.py:88
where insecure SSL/TLS protocol is allowed. Make a recommendation for fixing
Don't execute any git commands. I've already created a feature branch and will
take care of a pull request once satisfied with the proposed change
```

**- How to verify it**

CI tests

**- Description for the changelog**

fix: Avoid use of TLS < v1.2
